### PR TITLE
Simplify code by eliminating most else-clauses and returning early

### DIFF
--- a/jsonpointer.js
+++ b/jsonpointer.js
@@ -48,10 +48,9 @@ var set = function(obj, pointer, value) {
   validate_input(obj, pointer);
   if (pointer === "/") {
     return obj;
-  } else {
-    pointer = pointer.split("/").slice(1);
-    return traverse(obj, pointer, value);
   }
+  pointer = pointer.split("/").slice(1);
+  return traverse(obj, pointer, value);
 }
 
 exports.get = get


### PR DESCRIPTION
Attached patches simplify the code away from the stairs-shaped if-else-style to a more readable shape.
