### PR TITLE
Modify to support draft-ietf-appsawg-json-pointer-08

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JSON Pointer for nodejs
 
-This is an implementation of [JSON Pointer](http://tools.ietf.org/html/draft-pbryan-zyp-json-pointer-00).
+This is an implementation of [JSON Pointer](http://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-08).
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
 , "tags" : ["util", "simple", "util", "utility"]
 , "version" : "1.0.1"
 , "author" : "Jan Lehnardt <jan@apache.org>"
+, "contributors":
+  ["Joe Hildebrand <joe-github@cursive.net>"]
 , "repository" :
   { "type" : "git"
   , "url" : "http://github.com/janl/node-jsonpointer.git"

--- a/test.js
+++ b/test.js
@@ -31,7 +31,10 @@ assert.equal(jsonpointer.get(obj, "/d/e/0/a"), 4);
 assert.equal(jsonpointer.get(obj, "/d/e/1/b"), 5);
 assert.equal(jsonpointer.get(obj, "/d/e/2/c"), 6);
 
-assert.equal(jsonpointer.get(obj, "/"), obj);
+assert.equal(jsonpointer.get(obj, ""), obj);
+assert.throws(function() {
+  assert.equal(jsonpointer.get(obj, "a"), 3);
+});
 
 var complexKeys = {
   "a/b": {
@@ -39,13 +42,59 @@ var complexKeys = {
   },
   d: {
     "e/f": 2
-  }
+  },
+  "~1": 3,
+  "01": 4
 }
 
-assert.equal(jsonpointer.get(complexKeys, "/a%2Fb/c"), 1);
-assert.equal(jsonpointer.get(complexKeys, "/d/e%2Ff"), 2);
+assert.equal(jsonpointer.get(complexKeys, "/a~1b/c"), 1);
+assert.equal(jsonpointer.get(complexKeys, "/d/e~1f"), 2);
+assert.equal(jsonpointer.get(complexKeys, "/~01"), 3);
+assert.equal(jsonpointer.get(complexKeys, "/01"), 4);
 assert.throws(function() {
   assert.equal(jsonpointer.get(complexKeys, "/a/b/c"), 1);
 });
+assert.throws(function() {
+  assert.equal(jsonpointer.get(complexKeys, "/~1"), 3);
+});
+
+// draft-ietf-appsawg-json-pointer-08 has special array rules
+var ary = [ "zero", "one", "two" ];
+
+assert.throws(function() {
+  assert.equal(jsonpointer.get(ary, "/01"), "one");
+});
+//assert.equal(jsonpointer.set(ary, "/-", "three"), null);
+//assert.equal(ary[3], "three");
+
+// Examples from the draft:
+var example = {
+  "foo": ["bar", "baz"],
+  "": 0,
+  "a/b": 1,
+  "c%d": 2,
+  "e^f": 3,
+  "g|h": 4,
+  "i\\j": 5,
+  "k\"l": 6,
+  " ": 7,
+  "m~n": 8
+};
+
+assert.equal(jsonpointer.get(example, ""), example);
+var ans = jsonpointer.get(example, "/foo");
+assert.equal(ans.length, 2);
+assert.equal(ans[0], "bar");
+assert.equal(ans[1], "baz");
+assert.equal(jsonpointer.get(example, "/foo/0"), "bar");
+assert.equal(jsonpointer.get(example, "/"), 0);
+assert.equal(jsonpointer.get(example, "/a~1b"), 1);
+assert.equal(jsonpointer.get(example, "/c%d"), 2);
+assert.equal(jsonpointer.get(example, "/e^f"), 3);
+assert.equal(jsonpointer.get(example, "/g|h"), 4);
+assert.equal(jsonpointer.get(example, "/i\\j"), 5);
+assert.equal(jsonpointer.get(example, "/k\"l"), 6);
+assert.equal(jsonpointer.get(example, "/ "), 7);
+assert.equal(jsonpointer.get(example, "/m~0n"), 8);
 
 console.log("All tests pass.");


### PR DESCRIPTION
Change to the new escaping mechanism, and support "" keys by making "/" refer to obj[""], not obj, as specified in draft-ietf-appsawg-json-pointer-08.
