### PR TITLE
Return null when value not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is an implementation of [JSON Pointer](http://tools.ietf.org/html/draft-iet
     var three = jsonpointer.get(obj, "/qux/0");
     var four = jsonpointer.get(obj, "/qux/1");
     var five = jsonpointer.get(obj, "/qux/2");
+    var notfound = jsonpointer.get(obj, "/quo"); // returns null
 
     jsonpointer.set(obj, "/foo", 6); // obj.foo = 6;
 

--- a/jsonpointer.js
+++ b/jsonpointer.js
@@ -15,9 +15,8 @@ var untilde = function(str) {
 var traverse = function(obj, pointer, value) {
   // assert(isArray(pointer))
   var part = untilde(pointer.shift());
-  if(typeof obj[part] === "undefined") {
-    throw("Value for pointer '" + pointer + "' not found.");
-    return;
+  if(!obj.hasOwnProperty(part)) {
+    return null;
   }
   if(pointer.length !== 0) { // keep traversin!
     return traverse(obj[part], pointer, value);

--- a/test.js
+++ b/test.js
@@ -33,7 +33,10 @@ assert.equal(jsonpointer.get(obj, "/d/e/2/c"), 6);
 
 assert.equal(jsonpointer.get(obj, ""), obj);
 assert.throws(function() {
-  assert.equal(jsonpointer.get(obj, "a"), 3);
+  jsonpointer.get(obj, "a");
+});
+assert.throws(function() {
+  jsonpointer.get(obj, "a/");
 });
 
 var complexKeys = {
@@ -51,19 +54,13 @@ assert.equal(jsonpointer.get(complexKeys, "/a~1b/c"), 1);
 assert.equal(jsonpointer.get(complexKeys, "/d/e~1f"), 2);
 assert.equal(jsonpointer.get(complexKeys, "/~01"), 3);
 assert.equal(jsonpointer.get(complexKeys, "/01"), 4);
-assert.throws(function() {
-  assert.equal(jsonpointer.get(complexKeys, "/a/b/c"), 1);
-});
-assert.throws(function() {
-  assert.equal(jsonpointer.get(complexKeys, "/~1"), 3);
-});
+assert.equal(jsonpointer.get(complexKeys, "/a/b/c"), null);
+assert.equal(jsonpointer.get(complexKeys, "/~1"), null);
 
 // draft-ietf-appsawg-json-pointer-08 has special array rules
 var ary = [ "zero", "one", "two" ];
+assert.equal(jsonpointer.get(ary, "/01"), null);
 
-assert.throws(function() {
-  assert.equal(jsonpointer.get(ary, "/01"), "one");
-});
 //assert.equal(jsonpointer.set(ary, "/-", "three"), null);
 //assert.equal(ary[3], "three");
 


### PR DESCRIPTION
Throwing an exception is for exceptional cases.  Not finding the target data doesn't feel like an exceptional case, particularly if I'm going to use the pointer as a filter to select from a set of objects that might match.
