### PR TITLE
Move console module into devDependencies

### DIFF
--- a/jsonpointer.js
+++ b/jsonpointer.js
@@ -1,5 +1,3 @@
-var console = require("console");
-
 var untilde = function(str) {
   return str.replace(/~./g, function(m) {
     switch (m) {

--- a/package.json
+++ b/package.json
@@ -1,18 +1,33 @@
-{ "name" : "jsonpointer"
-, "description" : "Simple JSON Addressing."
-, "tags" : ["util", "simple", "util", "utility"]
-, "version" : "1.0.1"
-, "author" : "Jan Lehnardt <jan@apache.org>"
-, "contributors":
-  ["Joe Hildebrand <joe-github@cursive.net>"]
-, "repository" :
-  { "type" : "git"
-  , "url" : "http://github.com/janl/node-jsonpointer.git"
+{
+  "name": "jsonpointer",
+  "description": "Simple JSON Addressing.",
+  "tags": [
+    "util",
+    "simple",
+    "util",
+    "utility"
+  ],
+  "version": "1.0.1",
+  "author": "Jan Lehnardt <jan@apache.org>",
+  "contributors": [
+    "Joe Hildebrand <joe-github@cursive.net>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/janl/node-jsonpointer.git"
+  },
+  "bugs": {
+    "url": "http://github.com/janl/node-jsonpointer/issues"
+  },
+  "engines": [
+    "node >= 0.4.9"
+  ],
+  "main": "./jsonpointer",
+  "scripts": {
+    "test": "node test.js"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "console": "0.5.2"
   }
-, "bugs" :
-  { "url" : "http://github.com/janl/node-jsonpointer/issues" }
-, "engines" : ["node >= 0.4.9"]
-, "main" : "./jsonpointer"
-, "scripts" : { "test" : "node test.js" }
-, "license": "MIT"
 }


### PR DESCRIPTION
- Remove unused `require("console")` from `jsonpointer.js`
- Add console module used in tests to devdependencies