### PR TITLE
Add toString method to compiled pointer 

### DIFF
--- a/jsonpointer.js
+++ b/jsonpointer.js
@@ -77,7 +77,7 @@ function set (obj, pointer, value) {
 }
 
 function compile (pointer) {
-  var source = pointer.toString()
+  var source = pointer
   var compiled = compilePointer(pointer)
   return {
     get: function (object) {

--- a/jsonpointer.js
+++ b/jsonpointer.js
@@ -77,6 +77,7 @@ function set (obj, pointer, value) {
 }
 
 function compile (pointer) {
+  var source = pointer.toString()
   var compiled = compilePointer(pointer)
   return {
     get: function (object) {
@@ -84,6 +85,9 @@ function compile (pointer) {
     },
     set: function (object, value) {
       return set(object, compiled, value)
+    },
+    toString: function () {
+      return source.toString()
     }
   }
 }

--- a/test.js
+++ b/test.js
@@ -127,5 +127,6 @@ assert.equal(pointer.get(a), 'bar')
 assert.equal(pointer.set(a, 'test'), 'bar')
 assert.equal(pointer.get(a), 'test')
 assert.deepEqual(a, {foo: 'test'})
+assert.equal(pointer.toString(), '/foo')
 
 console.log('All tests pass.')


### PR DESCRIPTION
Hi @janl 

Wondering if you would consider this PR?  It provides a 'toString' method to the returned compiled pointer, such that you can retrieve the original pointer 'path' string that was compiled.  E.g.

```javascript
var jsonpointer = require('jsonpointer');
var obj = { foo: 1, bar: { baz: 2}, qux: [3, 4, 5]};

var pointer = jsonpointer.compile('/bar/baz') ;
pointer.toString() ; // outputs '/bar/baz'
```
