### PR TITLE
Include typings in npm distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "main": "./jsonpointer",
   "typings": "jsonpointer.d.ts",
   "files": [
-    "jsonpointer.js"
+    "jsonpointer.js",
+    "jsonpointer.d.ts"
   ],
   "scripts": {
     "test": "standard && node test.js",


### PR DESCRIPTION
fixes #36 

After this change you can see that npm includes the types:
```
$ npm pack
[...]
npm notice === Tarball Contents ===
npm notice 974B  package.json
npm notice 699B  jsonpointer.d.ts
npm notice 2.3kB jsonpointer.js
npm notice 1.2kB LICENSE.md
npm notice 1.3kB README.md
[...]
```
whereas before it wasn't.