### PR TITLE
Fix: null values throwing exception when traversing over while getting

### DIFF
--- a/jsonpointer.js
+++ b/jsonpointer.js
@@ -69,6 +69,7 @@ function get (obj, pointer) {
     obj = obj[untilde(pointer[p++])]
     if (len === p) return obj
     if (typeof obj !== 'object') return undefined
+    if (obj === null) return null
   }
 }
 

--- a/test.js
+++ b/test.js
@@ -8,7 +8,8 @@ var obj = {
   },
   d: {
     e: [{ a: 3 }, { b: 4 }, { c: 5 }]
-  }
+  },
+  nullValue: null
 }
 
 assert.equal(jsonpointer.get(obj, '/a'), 1)
@@ -16,6 +17,8 @@ assert.equal(jsonpointer.get(obj, '/b/c'), 2)
 assert.equal(jsonpointer.get(obj, '/d/e/0/a'), 3)
 assert.equal(jsonpointer.get(obj, '/d/e/1/b'), 4)
 assert.equal(jsonpointer.get(obj, '/d/e/2/c'), 5)
+assert.equal(jsonpointer.get(obj, '/nullValue'), null)
+assert.equal(jsonpointer.get(obj, '/nullValue/e'), null)
 
 // set returns old value
 assert.equal(jsonpointer.set(obj, '/a', 2), 1)
@@ -127,6 +130,12 @@ assert.equal(pointer.get(a), 'bar')
 assert.equal(pointer.set(a, 'test'), 'bar')
 assert.equal(pointer.get(a), 'test')
 assert.deepEqual(a, { foo: 'test' })
+
+
+// compile read null value
+var compileWithNullValue = { foo: 'bar' }
+var pointerNullValue = jsonpointer.compile('/foo2/baz')
+assert.equal(pointer.get(pointerNullValue), null)
 
 var b = {}
 jsonpointer.set({}, '/constructor/prototype/boo', 'polluted')


### PR DESCRIPTION
Previously getting any value, where an object in the path was null, would throw an exception, while it being `undefined` would not.

Example:
```javascript
const obj = {
   foo: null,
   baz: undefined
}

jsonpointer.get(obj, "/foo/baz") /// <--- This would throw
jsonpointer.get(obj, "/baz/foo") /// <---- This would not
```

The fix is simply also checking equality with `null` and then returning `null` (comparable to the undefined case, where it already returned null)