### PR TITLE
fix-prototype-pollution

### DIFF
--- a/jsonpointer.js
+++ b/jsonpointer.js
@@ -17,10 +17,9 @@ function setter (obj, pointer, value) {
   var part
   var hasNextPart
 
-  if (pointer[1] === 'constructor' && pointer[2] === 'prototype') return obj
-  if (pointer[1] === '__proto__') return obj
-
   for (var p = 1, len = pointer.length; p < len;) {
+    if (pointer[p] === 'constructor' || pointer[p] === 'prototype' || pointer[p] === '__proto__') return obj
+
     part = untilde(pointer[p++])
     hasNextPart = len > p
 
@@ -53,6 +52,11 @@ function compilePointer (pointer) {
     if (pointer[0] === '') return pointer
     throw new Error('Invalid JSON pointer.')
   } else if (Array.isArray(pointer)) {
+    pointer.forEach(function (part, i) {
+      if (typeof part !== 'string' && typeof part !== 'number') {
+        pointer[i] = '' + part
+      }
+    })
     return pointer
   }
 

--- a/jsonpointer.js
+++ b/jsonpointer.js
@@ -54,7 +54,7 @@ function compilePointer (pointer) {
   } else if (Array.isArray(pointer)) {
     for (const part of pointer) {
       if (typeof part !== 'string' && typeof part !== 'number') {
-        throw new Error('Invalid JSON pointer.')
+        throw new Error('Invalid JSON pointer. Must be of type string or number.')
       }
     }
     return pointer

--- a/jsonpointer.js
+++ b/jsonpointer.js
@@ -52,11 +52,11 @@ function compilePointer (pointer) {
     if (pointer[0] === '') return pointer
     throw new Error('Invalid JSON pointer.')
   } else if (Array.isArray(pointer)) {
-    pointer.forEach(function (part, i) {
+    for (const part of pointer) {
       if (typeof part !== 'string' && typeof part !== 'number') {
-        pointer[i] = '' + part
+        throw new Error('Invalid JSON pointer.')
       }
-    })
+    }
     return pointer
   }
 

--- a/test.js
+++ b/test.js
@@ -144,41 +144,20 @@ jsonpointer.set({}, '/foo/__proto__/__proto__/boo', 'polluted')
 assert(!d.boo, 'should not boo')
 
 var e = {}
-jsonpointer.set({}, '/constructor/prototype/boo', 'polluted')
-assert(!e.boo, 'should not boo')
-
 jsonpointer.set({}, '/foo/constructor/prototype/boo', 'polluted')
 assert(!e.boo, 'should not boo')
 
 jsonpointer.set({}, '/foo/constructor/constructor/prototype/boo', 'polluted')
 assert(!e.boo, 'should not boo')
 
-var f = {}
-jsonpointer.set({}, [['__proto__'], 'boo'], 'polluted')
-assert(!f.boo, 'should not f.boo')
-
-jsonpointer.set({}, [[['__proto__']], 'boo'], 'polluted')
-assert(!f.boo, 'should not f.boo')
-
-jsonpointer.set({}, [['__proto__'], ['__proto__'], 'boo'], 'polluted')
-assert(!f.boo, 'should not f.boo')
-
-jsonpointer.set({}, [[['__proto__']], [['__proto__']], 'boo'], 'polluted')
-assert(!f.boo, 'should not f.boo')
-
-jsonpointer.set({}, [['__proto__'], ['__proto__'], ['__proto__'], 'boo'], 'polluted')
-assert(!f.boo, 'should not f.boo')
-
-jsonpointer.set({}, [['foo'], ['__proto__'], 'boo'], 'polluted')
-assert(!f.boo, 'should not boo')
-
-jsonpointer.set({}, [['foo'], ['__proto__'], ['__proto__'], 'boo'], 'polluted')
-assert(!f.boo, 'should not boo')
-
-jsonpointer.set({}, [['constructor'], ['prototype'], 'boo'], 'polluted')
-assert(!f.boo, 'should not boo')
-
-jsonpointer.set({}, [['constructor'], ['constructor'], ['prototype'], 'boo'], 'polluted')
-assert(!f.boo, 'should not boo')
+assert.throws(function () { jsonpointer.set({}, [['__proto__'], 'boo'], 'polluted')}, validateError)
+assert.throws(function () { jsonpointer.set({}, [[['__proto__']], 'boo'], 'polluted')}, validateError)
+assert.throws(function () { jsonpointer.set({}, [['__proto__'], ['__proto__'], 'boo'], 'polluted')}, validateError)
+assert.throws(function () { jsonpointer.set({}, [[['__proto__']], [['__proto__']], 'boo'], 'polluted')}, validateError)
+assert.throws(function () { jsonpointer.set({}, [['__proto__'], ['__proto__'], ['__proto__'], 'boo'], 'polluted')}, validateError)
+assert.throws(function () { jsonpointer.set({}, [['foo'], ['__proto__'], 'boo'], 'polluted')}, validateError)
+assert.throws(function () { jsonpointer.set({}, [['foo'], ['__proto__'], ['__proto__'], 'boo'], 'polluted')}, validateError)
+assert.throws(function () { jsonpointer.set({}, [['constructor'], ['prototype'], 'boo'], 'polluted')}, validateError)
+assert.throws(function () { jsonpointer.set({}, [['constructor'], ['constructor'], ['prototype'], 'boo'], 'polluted')}, validateError)
 
 console.log('All tests pass.')

--- a/test.js
+++ b/test.js
@@ -136,4 +136,49 @@ var c = {}
 jsonpointer.set({}, '/__proto__/boo', 'polluted')
 assert(!c.boo, 'should not boo')
 
+var d = {}
+jsonpointer.set({}, '/foo/__proto__/boo', 'polluted')
+assert(!d.boo, 'should not boo')
+
+jsonpointer.set({}, '/foo/__proto__/__proto__/boo', 'polluted')
+assert(!d.boo, 'should not boo')
+
+var e = {}
+jsonpointer.set({}, '/constructor/prototype/boo', 'polluted')
+assert(!e.boo, 'should not boo')
+
+jsonpointer.set({}, '/foo/constructor/prototype/boo', 'polluted')
+assert(!e.boo, 'should not boo')
+
+jsonpointer.set({}, '/foo/constructor/constructor/prototype/boo', 'polluted')
+assert(!e.boo, 'should not boo')
+
+var f = {}
+jsonpointer.set({}, [['__proto__'], 'boo'], 'polluted')
+assert(!f.boo, 'should not f.boo')
+
+jsonpointer.set({}, [[['__proto__']], 'boo'], 'polluted')
+assert(!f.boo, 'should not f.boo')
+
+jsonpointer.set({}, [['__proto__'], ['__proto__'], 'boo'], 'polluted')
+assert(!f.boo, 'should not f.boo')
+
+jsonpointer.set({}, [[['__proto__']], [['__proto__']], 'boo'], 'polluted')
+assert(!f.boo, 'should not f.boo')
+
+jsonpointer.set({}, [['__proto__'], ['__proto__'], ['__proto__'], 'boo'], 'polluted')
+assert(!f.boo, 'should not f.boo')
+
+jsonpointer.set({}, [['foo'], ['__proto__'], 'boo'], 'polluted')
+assert(!f.boo, 'should not boo')
+
+jsonpointer.set({}, [['foo'], ['__proto__'], ['__proto__'], 'boo'], 'polluted')
+assert(!f.boo, 'should not boo')
+
+jsonpointer.set({}, [['constructor'], ['prototype'], 'boo'], 'polluted')
+assert(!f.boo, 'should not boo')
+
+jsonpointer.set({}, [['constructor'], ['constructor'], ['prototype'], 'boo'], 'polluted')
+assert(!f.boo, 'should not boo')
+
 console.log('All tests pass.')


### PR DESCRIPTION
Hi @janl,

Here is the PR for fixing the Prototype Pollution vulnerability we discussed by email.

The existing fix can by bypassed, for example, with the following payloads:
- adding a property before a dangerous path. This is because only `pointer[1] === '__proto__'` is checked 
```js
jsonpointer.set({}, '/foo/__proto__/boo', 'polluted')
```

- by a type confusion attack, where the path components are array:
```js
jsonpointer.set({}, [['__proto__'], ['__proto__'], 'boo'], 'polluted')
```
This is because the `===` operator returns always `false` when the operands are of different type.

This PR tries to address the above cases and adds more unit-tests.

Any feedback is more than welcome.