### PR TITLE
fix incorrect typings for compile get/set methods

### DIFF
--- a/jsonpointer.d.ts
+++ b/jsonpointer.d.ts
@@ -2,13 +2,13 @@ interface JSONPointer {
     /**
      * Looks up a JSON pointer in an object
      */
-    get(object: Object, pointer: string): any;
+    get(object: Object): any;
 
 
     /**
      * Set a value for a JSON pointer on object
      */
-    set(object: Object, pointer: string, value: any): void;
+    set(object: Object, value: any): void;
 }
 
 


### PR DESCRIPTION
The typings for get/set methods for compile are incorrect. The set method only accepts 1 param, and set method only accepts 2 params.

This PR fixes the typings for get/set method for compile function.