### PR TITLE
fix incorrect typings for compile get/set methods

### DIFF
--- a/jsonpointer.d.ts
+++ b/jsonpointer.d.ts
@@ -2,13 +2,13 @@ interface JSONPointer {
     /**
      * Looks up a JSON pointer in an object
      */
-    get(object: Object, pointer: string): any;
+    get(object: Object): any;
 
 
     /**
      * Set a value for a JSON pointer on object
      */
-    set(object: Object, pointer: string, value: any): void;
+    set(object: Object, value: any): void;
 }
 
 


### PR DESCRIPTION
The previous PR (https://github.com/janl/node-jsonpointer/pull/54) was closed on incorrect assumptions. I added a comment on it, but got no response, so I hope a new PR is fine. We use this library, and the incorrect typings are annoying and I would like to see it fixed :) 

So, let me try and clear up the confusion from the previous PR:

There is a get (https://github.com/janl/node-jsonpointer/blob/main/jsonpointer.js#L66) function that accepts 2 parameters, and
there is a set (https://github.com/janl/node-jsonpointer/blob/main/jsonpointer.js#L79) function that accept 3 parameters

Additionally, on the **compile object** 
there is also a get (https://github.com/janl/node-jsonpointer/blob/main/jsonpointer.js#L89) method that accepts 1 parameter, and 
there is also a set (https://github.com/janl/node-jsonpointer/blob/main/jsonpointer.js#L92) method that accepts 2 parameters. 

Currently in the typings, both variants accept 2 and 3 parameters, which is incorrect.

This is also demonstrated in the tests, f.ex here: https://github.com/janl/node-jsonpointer/blob/main/test.js#L14 and here, on the compile object where only 1 parameter is used for get: https://github.com/janl/node-jsonpointer/blob/main/test.js#L126 and 2 parameters is used for set: https://github.com/janl/node-jsonpointer/blob/main/test.js#L127


This PR fixes the incorrect typings for the get/set methods on the compile object.

Thanks for the great library, I hope you will consider accepting this fix :) 
