### PR TITLE
Always use strictEqual to ensure null and undefined values are asserted correctly

### DIFF
--- a/test.js
+++ b/test.js
@@ -11,42 +11,42 @@ var obj = {
   }
 }
 
-assert.equal(jsonpointer.get(obj, '/a'), 1)
-assert.equal(jsonpointer.get(obj, '/b/c'), 2)
-assert.equal(jsonpointer.get(obj, '/d/e/0/a'), 3)
-assert.equal(jsonpointer.get(obj, '/d/e/1/b'), 4)
-assert.equal(jsonpointer.get(obj, '/d/e/2/c'), 5)
+assert.strictEqual(jsonpointer.get(obj, '/a'), 1)
+assert.strictEqual(jsonpointer.get(obj, '/b/c'), 2)
+assert.strictEqual(jsonpointer.get(obj, '/d/e/0/a'), 3)
+assert.strictEqual(jsonpointer.get(obj, '/d/e/1/b'), 4)
+assert.strictEqual(jsonpointer.get(obj, '/d/e/2/c'), 5)
 
 // set returns old value
-assert.equal(jsonpointer.set(obj, '/a', 2), 1)
-assert.equal(jsonpointer.set(obj, '/b/c', 3), 2)
-assert.equal(jsonpointer.set(obj, '/d/e/0/a', 4), 3)
-assert.equal(jsonpointer.set(obj, '/d/e/1/b', 5), 4)
-assert.equal(jsonpointer.set(obj, '/d/e/2/c', 6), 5)
+assert.strictEqual(jsonpointer.set(obj, '/a', 2), 1)
+assert.strictEqual(jsonpointer.set(obj, '/b/c', 3), 2)
+assert.strictEqual(jsonpointer.set(obj, '/d/e/0/a', 4), 3)
+assert.strictEqual(jsonpointer.set(obj, '/d/e/1/b', 5), 4)
+assert.strictEqual(jsonpointer.set(obj, '/d/e/2/c', 6), 5)
 
 // set nested properties
-assert.equal(jsonpointer.set(obj, '/f/g/h/i', 6), undefined)
-assert.equal(jsonpointer.get(obj, '/f/g/h/i'), 6)
+assert.strictEqual(jsonpointer.set(obj, '/f/g/h/i', 6), undefined)
+assert.strictEqual(jsonpointer.get(obj, '/f/g/h/i'), 6)
 
 // set an array
-assert.equal(jsonpointer.set(obj, '/f/g/h/foo/-', 'test'), undefined)
+assert.strictEqual(jsonpointer.set(obj, '/f/g/h/foo/-', 'test'), undefined)
 var arr = jsonpointer.get(obj, '/f/g/h/foo')
 assert(Array.isArray(arr), 'set /- creates an array.')
-assert.equal(arr[0], 'test')
+assert.strictEqual(arr[0], 'test')
 
-assert.equal(jsonpointer.get(obj, '/a'), 2)
-assert.equal(jsonpointer.get(obj, '/b/c'), 3)
-assert.equal(jsonpointer.get(obj, '/d/e/0/a'), 4)
-assert.equal(jsonpointer.get(obj, '/d/e/1/b'), 5)
-assert.equal(jsonpointer.get(obj, '/d/e/2/c'), 6)
+assert.strictEqual(jsonpointer.get(obj, '/a'), 2)
+assert.strictEqual(jsonpointer.get(obj, '/b/c'), 3)
+assert.strictEqual(jsonpointer.get(obj, '/d/e/0/a'), 4)
+assert.strictEqual(jsonpointer.get(obj, '/d/e/1/b'), 5)
+assert.strictEqual(jsonpointer.get(obj, '/d/e/2/c'), 6)
 
 // can set `null` as a value
-assert.equal(jsonpointer.set(obj, '/f/g/h/foo/0', null), 'test')
+assert.strictEqual(jsonpointer.set(obj, '/f/g/h/foo/0', null), 'test')
 assert.strictEqual(jsonpointer.get(obj, '/f/g/h/foo/0'), null)
-assert.equal(jsonpointer.set(obj, '/b/c', null), 3)
+assert.strictEqual(jsonpointer.set(obj, '/b/c', null), 3)
 assert.strictEqual(jsonpointer.get(obj, '/b/c'), null)
 
-assert.equal(jsonpointer.get(obj, ''), obj)
+assert.strictEqual(jsonpointer.get(obj, ''), obj)
 assert.throws(function () { jsonpointer.get(obj, 'a') }, validateError)
 assert.throws(function () { jsonpointer.get(obj, 'a/') }, validateError)
 
@@ -76,19 +76,19 @@ var complexKeys = {
   '01': 4
 }
 
-assert.equal(jsonpointer.get(complexKeys, '/a~1b/c'), 1)
-assert.equal(jsonpointer.get(complexKeys, '/d/e~1f'), 2)
-assert.equal(jsonpointer.get(complexKeys, '/~01'), 3)
-assert.equal(jsonpointer.get(complexKeys, '/01'), 4)
-assert.equal(jsonpointer.get(complexKeys, '/a/b/c'), null)
-assert.equal(jsonpointer.get(complexKeys, '/~1'), null)
+assert.strictEqual(jsonpointer.get(complexKeys, '/a~1b/c'), 1)
+assert.strictEqual(jsonpointer.get(complexKeys, '/d/e~1f'), 2)
+assert.strictEqual(jsonpointer.get(complexKeys, '/~01'), 3)
+assert.strictEqual(jsonpointer.get(complexKeys, '/01'), 4)
+assert.strictEqual(jsonpointer.get(complexKeys, '/a/b/c'), undefined)
+assert.strictEqual(jsonpointer.get(complexKeys, '/~1'), undefined)
 
 // draft-ietf-appsawg-json-pointer-08 has special array rules
 var ary = ['zero', 'one', 'two']
-assert.equal(jsonpointer.get(ary, '/01'), null)
+assert.strictEqual(jsonpointer.get(ary, '/01'), undefined)
 
-assert.equal(jsonpointer.set(ary, '/-', 'three'), null)
-assert.equal(ary[3], 'three')
+assert.strictEqual(jsonpointer.set(ary, '/-', 'three'), undefined)
+assert.strictEqual(ary[3], 'three')
 
 // Examples from the draft:
 var example = {
@@ -104,28 +104,28 @@ var example = {
   'm~n': 8
 }
 
-assert.equal(jsonpointer.get(example, ''), example)
+assert.strictEqual(jsonpointer.get(example, ''), example)
 var ans = jsonpointer.get(example, '/foo')
-assert.equal(ans.length, 2)
-assert.equal(ans[0], 'bar')
-assert.equal(ans[1], 'baz')
-assert.equal(jsonpointer.get(example, '/foo/0'), 'bar')
-assert.equal(jsonpointer.get(example, '/'), 0)
-assert.equal(jsonpointer.get(example, '/a~1b'), 1)
-assert.equal(jsonpointer.get(example, '/c%d'), 2)
-assert.equal(jsonpointer.get(example, '/e^f'), 3)
-assert.equal(jsonpointer.get(example, '/g|h'), 4)
-assert.equal(jsonpointer.get(example, '/i\\j'), 5)
-assert.equal(jsonpointer.get(example, '/k\'l'), 6)
-assert.equal(jsonpointer.get(example, '/ '), 7)
-assert.equal(jsonpointer.get(example, '/m~0n'), 8)
+assert.strictEqual(ans.length, 2)
+assert.strictEqual(ans[0], 'bar')
+assert.strictEqual(ans[1], 'baz')
+assert.strictEqual(jsonpointer.get(example, '/foo/0'), 'bar')
+assert.strictEqual(jsonpointer.get(example, '/'), 0)
+assert.strictEqual(jsonpointer.get(example, '/a~1b'), 1)
+assert.strictEqual(jsonpointer.get(example, '/c%d'), 2)
+assert.strictEqual(jsonpointer.get(example, '/e^f'), 3)
+assert.strictEqual(jsonpointer.get(example, '/g|h'), 4)
+assert.strictEqual(jsonpointer.get(example, '/i\\j'), 5)
+assert.strictEqual(jsonpointer.get(example, '/k\'l'), 6)
+assert.strictEqual(jsonpointer.get(example, '/ '), 7)
+assert.strictEqual(jsonpointer.get(example, '/m~0n'), 8)
 
 // jsonpointer.compile(path)
 var a = { foo: 'bar' }
 var pointer = jsonpointer.compile('/foo')
-assert.equal(pointer.get(a), 'bar')
-assert.equal(pointer.set(a, 'test'), 'bar')
-assert.equal(pointer.get(a), 'test')
+assert.strictEqual(pointer.get(a), 'bar')
+assert.strictEqual(pointer.set(a, 'test'), 'bar')
+assert.strictEqual(pointer.get(a), 'test')
 assert.deepEqual(a, { foo: 'test' })
 
 var b = {}


### PR DESCRIPTION
Just saw that some assertions were wrong.
`assert.equal` is deprecated and behaves slightly different with null/undefined.

```patch
const obj = {a: 'foo'}
// This returned undefined, but accepted null in the comparison
- assert.equal(jsonpointer.get(obj, '/b'), null)
+ assert.strictEqual(jsonpointer.get(obj, '/b'), undefined)
```

Migrating everything to `assert.strictEqual` is more explicit.