### PR TITLE
fix: correct export

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "main": "./jsonpointer",
-  "typings": "jsonpointer.d.ts",
+  "main": "./jsonpointer.js",
+  "typings": "./jsonpointer.d.ts",
   "files": [
     "jsonpointer.js",
     "jsonpointer.d.ts"


### PR DESCRIPTION
This fixes `jsonpointer` can not be `require` on vercel

https://github.com/vite-pwa/vite-plugin-pwa/issues/667#issuecomment-2469954352